### PR TITLE
feat: snackbar feedback on invalid height input

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -339,7 +339,28 @@ a:hover {
   text-decoration: none;
 }
 
+.snackbar {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(calc(100% + 1.5rem));
+  background: var(--text);
+  color: var(--bg);
+  padding: 0.65rem 1.25rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  transition: transform 0.2s ease;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.snackbar.visible {
+  transform: translateX(-50%) translateY(0);
+}
+
 @media (max-width: 600px) {
   header { padding: 1rem 1.25rem; }
   main { padding: 2.5rem 1.25rem; }
+  .snackbar { white-space: normal; text-align: center; width: calc(100% - 3rem); }
 }

--- a/barbell-collar-1inch-to-2inch-adapter.md
+++ b/barbell-collar-1inch-to-2inch-adapter.md
@@ -101,13 +101,36 @@ title: Barbell Collar 1 Inch to 2 Inch Adapter
     update_price();
   });
 
+  var snackbar_timeout = null;
+
+  function show_snackbar(message) {
+    var snackbar = document.getElementById('snackbar');
+    snackbar.textContent = message;
+    snackbar.classList.add('visible');
+    clearTimeout(snackbar_timeout);
+    snackbar_timeout = setTimeout(function() {
+      snackbar.classList.remove('visible');
+    }, 3000);
+  }
+
   document.getElementById('height-input').addEventListener('change', function() {
     var height_value = this.valueAsNumber;
-    if (Number.isInteger(height_value) && height_value >= CONFIG.height_min_mm && height_value <= CONFIG.height_max_mm) {
-      height_mm = height_value;
+    if (isNaN(height_value) || !Number.isInteger(height_value)) {
+      this.value = height_mm;
+      show_snackbar('Height must be a whole number between ' + CONFIG.height_min_mm + ' and ' + CONFIG.height_max_mm + ' mm');
+    } else if (height_value < CONFIG.height_min_mm) {
+      height_mm = CONFIG.height_min_mm;
+      this.value = height_mm;
+      show_snackbar('Height snapped to minimum: ' + CONFIG.height_min_mm + ' mm');
+      update_price();
+    } else if (height_value > CONFIG.height_max_mm) {
+      height_mm = CONFIG.height_max_mm;
+      this.value = height_mm;
+      show_snackbar('Height snapped to maximum: ' + CONFIG.height_max_mm + ' mm');
       update_price();
     } else {
-      this.value = height_mm;
+      height_mm = height_value;
+      update_price();
     }
   });
 
@@ -148,3 +171,5 @@ title: Barbell Collar 1 Inch to 2 Inch Adapter
 </script>
 
 <a href="{{ '/' | relative_url }}" class="back-link">← Back to shop</a>
+
+<div class="snackbar" id="snackbar"></div>


### PR DESCRIPTION
## Summary
- Snackbar slides up from the bottom when an invalid height is entered
- Out-of-range values now clamp to min/max (15mm or 70mm) instead of resetting to the previous value
- Non-numeric input resets to the previous valid value
- Snackbar auto-dismisses after 3 seconds

## Test plan
- [ ] Enter a value below 15 — should snap to 15mm with snackbar "Height snapped to minimum: 15mm"
- [ ] Enter a value above 70 — should snap to 70mm with snackbar "Height snapped to maximum: 70mm"
- [ ] Enter a decimal (e.g. 22.5) — should reset to previous value with snackbar
- [ ] Enter letters — should reset to previous value with snackbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)