### PR TITLE
refactor: extract product JS to assets/product.js

### DIFF
--- a/assets/product.js
+++ b/assets/product.js
@@ -1,0 +1,134 @@
+(function () {
+  var config_element = document.getElementById('product-config');
+  var CONFIG = {
+    standard_us_sleeve_diameter_mm: parseFloat(config_element.dataset.usDiameter),
+    standard_eu_sleeve_diameter_mm: parseFloat(config_element.dataset.euDiameter),
+    outer_diameter_mm:              parseFloat(config_element.dataset.outerDiameter),
+    height_min_mm:                  parseFloat(config_element.dataset.heightMin),
+    height_max_mm:                  parseFloat(config_element.dataset.heightMax),
+    default_height_mm:              parseFloat(config_element.dataset.heightDefault)
+  };
+
+  var WORKER_URL = config_element.dataset.workerUrl;
+
+  var inner_diameter_mm = CONFIG.standard_us_sleeve_diameter_mm;
+  var height_mm = CONFIG.default_height_mm;
+  var quantity = 'single';
+  var snackbar_timeout = null;
+
+  // Returns { clamped, value, message } — value and message only set when clamped or invalid
+  function validate_height(height_value) {
+    if (isNaN(height_value) || !Number.isInteger(height_value)) {
+      return { valid: false, message: 'Height must be a whole number between ' + CONFIG.height_min_mm + ' and ' + CONFIG.height_max_mm + ' mm' };
+    }
+    if (height_value < CONFIG.height_min_mm) {
+      return { valid: true, clamped: true, value: CONFIG.height_min_mm, message: 'Height snapped to minimum: ' + CONFIG.height_min_mm + ' mm' };
+    }
+    if (height_value > CONFIG.height_max_mm) {
+      return { valid: true, clamped: true, value: CONFIG.height_max_mm, message: 'Height snapped to maximum: ' + CONFIG.height_max_mm + ' mm' };
+    }
+    return { valid: true, clamped: false, value: height_value };
+  }
+
+  function show_snackbar(message) {
+    var snackbar = document.getElementById('snackbar');
+    snackbar.textContent = message;
+    snackbar.classList.add('visible');
+    clearTimeout(snackbar_timeout);
+    snackbar_timeout = setTimeout(function () {
+      snackbar.classList.remove('visible');
+    }, 3000);
+  }
+
+  async function update_price() {
+    var price_element = document.getElementById('product-price');
+    var units = quantity === 'pair' ? 2 : 1;
+    var params = new URLSearchParams({
+      inner_diameter_mm: inner_diameter_mm,
+      outer_diameter_mm: CONFIG.outer_diameter_mm,
+      height_mm: height_mm,
+      quantity: units
+    });
+    try {
+      var response = await fetch(WORKER_URL + '/price?' + params);
+      var data = await response.json();
+      price_element.textContent = 'CHF ' + data.total_price_chf.toFixed(2);
+    } catch (error) {
+      price_element.textContent = 'CHF —';
+    }
+  }
+
+  function select_option(group_id, clicked_button) {
+    document.querySelectorAll('#' + group_id + ' .variant-btn').forEach(function (button) {
+      button.classList.remove('active');
+    });
+    clicked_button.classList.add('active');
+  }
+
+  document.getElementById('inner-diameter-options').addEventListener('click', function (event) {
+    var clicked_button = event.target.closest('.variant-btn');
+    if (!clicked_button) return;
+    inner_diameter_mm = parseFloat(clicked_button.dataset.value);
+    select_option('inner-diameter-options', clicked_button);
+    update_price();
+  });
+
+  document.getElementById('quantity-options').addEventListener('click', function (event) {
+    var clicked_button = event.target.closest('.variant-btn');
+    if (!clicked_button) return;
+    quantity = clicked_button.dataset.value;
+    select_option('quantity-options', clicked_button);
+    update_price();
+  });
+
+  document.getElementById('height-input').addEventListener('change', function () {
+    var result = validate_height(this.valueAsNumber);
+    if (!result.valid) {
+      this.value = height_mm;
+      show_snackbar(result.message);
+    } else if (result.clamped) {
+      height_mm = result.value;
+      this.value = height_mm;
+      show_snackbar(result.message);
+      update_price();
+    } else {
+      height_mm = result.value;
+      update_price();
+    }
+  });
+
+  document.getElementById('checkout-btn').addEventListener('click', async function () {
+    var checkout_button = document.getElementById('checkout-btn');
+    var error_element = document.getElementById('checkout-error');
+    checkout_button.disabled = true;
+    checkout_button.textContent = 'Processing...';
+    error_element.textContent = '';
+
+    var items = [{
+      inner_diameter_mm: inner_diameter_mm,
+      outer_diameter_mm: CONFIG.outer_diameter_mm,
+      height_mm: height_mm,
+      quantity: quantity === 'pair' ? 2 : 1
+    }];
+
+    try {
+      var response = await fetch(WORKER_URL + '/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: items })
+      });
+      var data = await response.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        throw new Error(data.error || 'Unexpected error');
+      }
+    } catch (error) {
+      error_element.textContent = 'Checkout failed — please try again.';
+      checkout_button.disabled = false;
+      checkout_button.textContent = 'Buy Now';
+    }
+  });
+
+  update_price();
+})();

--- a/barbell-collar-1inch-to-2inch-adapter.md
+++ b/barbell-collar-1inch-to-2inch-adapter.md
@@ -12,6 +12,16 @@ title: Barbell Collar 1 Inch to 2 Inch Adapter
   Solid construction, secure fit — no wobble, no compromise.
 </p>
 
+<div id="product-config"
+  data-us-diameter="{{ site.data.collar_config.standard_us_sleeve_diameter_mm }}"
+  data-eu-diameter="{{ site.data.collar_config.standard_eu_sleeve_diameter_mm }}"
+  data-outer-diameter="{{ site.data.collar_config.outer_diameter_mm }}"
+  data-height-min="{{ site.data.collar_config.height_min_mm }}"
+  data-height-max="{{ site.data.collar_config.height_max_mm }}"
+  data-height-default="{{ site.data.collar_config.default_height_mm }}"
+  data-worker-url="https://mitthen-checkout.mitthen-com.workers.dev"
+></div>
+
 <div class="variant-selector">
   <div class="variant-group">
     <div class="variant-label">Inner Diameter</div>
@@ -49,127 +59,8 @@ title: Barbell Collar 1 Inch to 2 Inch Adapter
   <div class="checkout-error" id="checkout-error"></div>
 </div>
 
-<script>
-  var CONFIG = {
-    standard_us_sleeve_diameter_mm: {{ site.data.collar_config.standard_us_sleeve_diameter_mm }},
-    standard_eu_sleeve_diameter_mm: {{ site.data.collar_config.standard_eu_sleeve_diameter_mm }},
-    outer_diameter_mm:              {{ site.data.collar_config.outer_diameter_mm }},
-    height_min_mm:                  {{ site.data.collar_config.height_min_mm }},
-    height_max_mm:                  {{ site.data.collar_config.height_max_mm }},
-    default_height_mm:              {{ site.data.collar_config.default_height_mm }}
-  };
-
-  var WORKER_URL = 'https://mitthen-checkout.mitthen-com.workers.dev';
-
-  var inner_diameter_mm = CONFIG.standard_us_sleeve_diameter_mm;
-  var height_mm = CONFIG.default_height_mm;
-  var quantity = 'single';
-
-  async function update_price() {
-    var price_element = document.getElementById('product-price');
-    var units = quantity === 'pair' ? 2 : 1;
-    var params = new URLSearchParams({
-      inner_diameter_mm: inner_diameter_mm,
-      outer_diameter_mm: CONFIG.outer_diameter_mm,
-      height_mm: height_mm,
-      quantity: units
-    });
-    try {
-      var response = await fetch(WORKER_URL + '/price?' + params);
-      var data = await response.json();
-      price_element.textContent = 'CHF ' + data.total_price_chf.toFixed(2);
-    } catch (error) {
-      price_element.textContent = 'CHF —';
-    }
-  }
-
-  document.getElementById('inner-diameter-options').addEventListener('click', function(event) {
-    var clicked_button = event.target.closest('.variant-btn');
-    if (!clicked_button) return;
-    inner_diameter_mm = parseFloat(clicked_button.dataset.value);
-    document.querySelectorAll('#inner-diameter-options .variant-btn').forEach(function(button) { button.classList.remove('active'); });
-    clicked_button.classList.add('active');
-    update_price();
-  });
-
-  document.getElementById('quantity-options').addEventListener('click', function(event) {
-    var clicked_button = event.target.closest('.variant-btn');
-    if (!clicked_button) return;
-    quantity = clicked_button.dataset.value;
-    document.querySelectorAll('#quantity-options .variant-btn').forEach(function(button) { button.classList.remove('active'); });
-    clicked_button.classList.add('active');
-    update_price();
-  });
-
-  var snackbar_timeout = null;
-
-  function show_snackbar(message) {
-    var snackbar = document.getElementById('snackbar');
-    snackbar.textContent = message;
-    snackbar.classList.add('visible');
-    clearTimeout(snackbar_timeout);
-    snackbar_timeout = setTimeout(function() {
-      snackbar.classList.remove('visible');
-    }, 3000);
-  }
-
-  document.getElementById('height-input').addEventListener('change', function() {
-    var height_value = this.valueAsNumber;
-    if (isNaN(height_value) || !Number.isInteger(height_value)) {
-      this.value = height_mm;
-      show_snackbar('Height must be a whole number between ' + CONFIG.height_min_mm + ' and ' + CONFIG.height_max_mm + ' mm');
-    } else if (height_value < CONFIG.height_min_mm) {
-      height_mm = CONFIG.height_min_mm;
-      this.value = height_mm;
-      show_snackbar('Height snapped to minimum: ' + CONFIG.height_min_mm + ' mm');
-      update_price();
-    } else if (height_value > CONFIG.height_max_mm) {
-      height_mm = CONFIG.height_max_mm;
-      this.value = height_mm;
-      show_snackbar('Height snapped to maximum: ' + CONFIG.height_max_mm + ' mm');
-      update_price();
-    } else {
-      height_mm = height_value;
-      update_price();
-    }
-  });
-
-  document.getElementById('checkout-btn').addEventListener('click', async function() {
-    var checkout_button = document.getElementById('checkout-btn');
-    var error_element = document.getElementById('checkout-error');
-    checkout_button.disabled = true;
-    checkout_button.textContent = 'Processing...';
-    error_element.textContent = '';
-
-    var items = [{
-      inner_diameter_mm: inner_diameter_mm,
-      outer_diameter_mm: CONFIG.outer_diameter_mm,
-      height_mm: height_mm,
-      quantity: quantity === 'pair' ? 2 : 1
-    }];
-
-    try {
-      var response = await fetch(WORKER_URL + '/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ items: items })
-      });
-      var data = await response.json();
-      if (data.url) {
-        window.location.href = data.url;
-      } else {
-        throw new Error(data.error || 'Unexpected error');
-      }
-    } catch (error) {
-      error_element.textContent = 'Checkout failed — please try again.';
-      checkout_button.disabled = false;
-      checkout_button.textContent = 'Buy Now';
-    }
-  });
-
-  update_price();
-</script>
-
 <a href="{{ '/' | relative_url }}" class="back-link">← Back to shop</a>
 
 <div class="snackbar" id="snackbar"></div>
+
+<script src="{{ '/assets/product.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- All JS moved out of the markdown file into `assets/product.js`
- Markdown now contains only structure and Liquid config — no logic
- Config injected via `data-*` attributes on `#product-config` element (no inline `<script>`)
- `validate_height()` extracted as a named function with a clear return shape
- `select_option()` extracted to remove duplicated event handler logic
- IIFE wrapper to avoid polluting the global scope
- Worker URL comes from `data-worker-url` attribute (config, not code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)