### PR TITLE
feat: add Cloudflare Pages PR preview deployment workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,33 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Jekyll site
+        uses: docker://jekyll/builder:latest
+        env:
+          JEKYLL_ENV: production
+        with:
+          args: jekyll build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: mitthen-preview
+          directory: _site
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/preview.yml` that triggers on `pull_request` events (opened, synchronize, reopened)
- Builds the Jekyll site using `docker://jekyll/builder:latest` with `JEKYLL_ENV=production` (no Gemfile present in this repo)
- Deploys `_site/` output to Cloudflare Pages (`projectName: mitthen-preview`) using `cloudflare/pages-action@v1`
- Posts a preview URL automatically as a GitHub deployment status via `GITHUB_TOKEN`

## Setup required before merging

1. Create a Cloudflare Pages project named `mitthen-preview` in your Cloudflare dashboard (connected to this repo or as a direct upload project)
2. Add these two secrets to the GitHub repo (`Settings → Secrets and variables → Actions`):
   - `CLOUDFLARE_API_TOKEN` — a Cloudflare API token with Pages edit permissions
   - `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account ID

## Test plan

- [ ] Merge this PR, then open a new test PR and verify the Actions workflow runs
- [ ] Confirm a preview URL appears on the PR as a deployment status link
- [ ] Verify the deployed preview renders the Jekyll site correctly

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)