### PR TITLE
feat: replace height number input with range slider

### DIFF
--- a/assets/product.js
+++ b/assets/product.js
@@ -79,24 +79,32 @@
         '<div class="variant-group">' +
           '<div class="variant-label">Height</div>' +
           '<div class="variant-height-wrap">' +
-            '<input type="number" id="height-input"' +
+            '<input type="range" id="height-input"' +
               ' min="' + CONFIG.height_min_mm + '"' +
               ' max="' + CONFIG.height_max_mm + '"' +
               ' value="' + CONFIG.default_height_mm + '"' +
               ' step="1">' +
-            '<span class="variant-unit">mm</span>' +
-            '<span class="variant-hint">(' + CONFIG.height_min_mm + '&ndash;' + CONFIG.height_max_mm + ')</span>' +
+            '<span class="variant-height-value" id="height-value">' + CONFIG.default_height_mm + ' mm</span>' +
           '</div>' +
         '</div>';
 
-      this.querySelector('#height-input').addEventListener('change', function () {
+      var input = this.querySelector('#height-input');
+      var label = this.querySelector('#height-value');
+
+      input.addEventListener('input', function () {
+        label.textContent = this.valueAsNumber + ' mm';
+      });
+
+      input.addEventListener('change', function () {
         var result = validate_height(this.valueAsNumber);
         if (!result.valid) {
           this.value = state.height_mm;
+          label.textContent = state.height_mm + ' mm';
           show_snackbar(result.message);
         } else if (result.clamped) {
           state.height_mm = result.value;
           this.value = state.height_mm;
+          label.textContent = state.height_mm + ' mm';
           show_snackbar(result.message);
           notify_price_elements();
         } else {

--- a/assets/style.css
+++ b/assets/style.css
@@ -291,42 +291,48 @@ a:hover {
 .variant-height-wrap {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.variant-height-wrap input[type="number"] {
-  width: 5rem;
-  padding: 0.45rem 0.6rem;
-  border: 1.5px solid var(--border);
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text);
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 0.9rem;
-  outline: none;
-  transition: border-color 0.15s;
-  -moz-appearance: textfield;
-}
-
-.variant-height-wrap input[type="number"]::-webkit-outer-spin-button,
-.variant-height-wrap input[type="number"]::-webkit-inner-spin-button {
+.variant-height-wrap input[type="range"] {
+  flex: 1;
+  max-width: 260px;
+  height: 4px;
+  accent-color: var(--accent);
+  cursor: pointer;
+  appearance: none;
   -webkit-appearance: none;
-  margin: 0;
+  background: var(--border);
+  border-radius: 2px;
+  outline: none;
 }
 
-.variant-height-wrap input[type="number"]:focus {
-  border-color: var(--text);
+.variant-height-wrap input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1.5px var(--accent);
 }
 
-.variant-unit {
+.variant-height-wrap input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1.5px var(--accent);
+}
+
+.variant-height-value {
   font-size: 0.9rem;
-  color: var(--muted);
-}
-
-.variant-hint {
-  font-size: 0.8rem;
-  color: var(--muted);
-  font-weight: 300;
+  color: var(--text);
+  font-weight: 500;
+  min-width: 4rem;
 }
 
 .back-link {


### PR DESCRIPTION
Closes #8

Replaces the manual number entry with a range slider (15–70 mm). A live label next to the slider shows the current value (e.g. "32 mm") updating on every drag. Validation and price update logic are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)