### PR TITLE
feat: implement cart with localStorage persistence

### DIFF
--- a/_layouts/barbell-adapter.html
+++ b/_layouts/barbell-adapter.html
@@ -15,5 +15,6 @@ layout: default
 {{ content }}
 
 <div class="snackbar" id="snackbar"></div>
+<cart-drawer></cart-drawer>
 
 <script src="{{ '/assets/product.js' | relative_url }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,40 @@
       <img src="{{ '/assets/logo.png' | relative_url }}" alt="{{ site.title }} logo" class="brand-logo">
       {{ site.title }}
     </a>
+    <button class="cart-icon-btn" id="cart-icon-btn" aria-label="Open cart">
+      <svg class="cart-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"></path>
+        <line x1="3" y1="6" x2="21" y2="6"></line>
+        <path d="M16 10a4 4 0 0 1-8 0"></path>
+      </svg>
+      <span class="cart-badge" id="cart-badge" hidden>0</span>
+    </button>
   </header>
+  <script>
+    (function () {
+      var CART_KEY = 'mitthen_cart';
+      function get_count() {
+        try {
+          var items = JSON.parse(localStorage.getItem(CART_KEY)) || [];
+          return items.reduce(function (s, i) { return s + i.quantity; }, 0);
+        } catch (e) { return 0; }
+      }
+      function update_badge() {
+        var badge = document.getElementById('cart-badge');
+        if (!badge) return;
+        var n = get_count();
+        badge.textContent = n;
+        if (n > 0) { badge.removeAttribute('hidden'); } else { badge.setAttribute('hidden', ''); }
+      }
+      update_badge();
+      window.addEventListener('mitthen:cart-updated', update_badge);
+      window.addEventListener('storage', function (e) { if (e.key === CART_KEY) update_badge(); });
+      document.getElementById('cart-icon-btn').addEventListener('click', function () {
+        var drawer = document.querySelector('cart-drawer');
+        if (drawer) { drawer.open(); }
+      });
+    })();
+  </script>
   <main>
     {{ content }}
   </main>

--- a/assets/product.js
+++ b/assets/product.js
@@ -18,6 +18,53 @@
 
   var snackbar_timeout = null;
 
+  // ── Cart helpers ──────────────────────────────────────────────────────────
+
+  var CART_KEY = 'mitthen_cart';
+
+  function cart_load() {
+    try {
+      return JSON.parse(localStorage.getItem(CART_KEY)) || [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function cart_save(items) {
+    localStorage.setItem(CART_KEY, JSON.stringify(items));
+    cart_notify();
+  }
+
+  function cart_add(item) {
+    var items = cart_load();
+    var match = items.find(function (i) {
+      return i.inner_diameter_mm === item.inner_diameter_mm &&
+             i.outer_diameter_mm === item.outer_diameter_mm &&
+             i.height_mm         === item.height_mm;
+    });
+    if (match) {
+      match.quantity += item.quantity;
+    } else {
+      items.push(item);
+    }
+    cart_save(items);
+    return items;
+  }
+
+  function cart_remove(index) {
+    var items = cart_load();
+    items.splice(index, 1);
+    cart_save(items);
+    return items;
+  }
+
+  /** Broadcast so header badge and open drawer refresh. */
+  function cart_notify() {
+    window.dispatchEvent(new CustomEvent('mitthen:cart-updated'));
+  }
+
+  // ── Shared utilities ──────────────────────────────────────────────────────
+
   function validate_height(height_value) {
     if (isNaN(height_value) || !Number.isInteger(height_value)) {
       return { valid: false, message: 'Height must be a whole number between ' + CONFIG.height_min_mm + ' and ' + CONFIG.height_max_mm + ' mm' };
@@ -201,6 +248,165 @@
           btn.textContent = 'Buy Now';
         }
       }.bind(this));
+    }
+  });
+
+  customElements.define('add-to-cart-button', class extends HTMLElement {
+    connectedCallback() {
+      this.innerHTML = '<button class="add-to-cart-btn" id="add-to-cart-btn">Add to Cart</button>';
+
+      this.querySelector('#add-to-cart-btn').addEventListener('click', function () {
+        var item = {
+          inner_diameter_mm: state.inner_diameter_mm,
+          outer_diameter_mm: CONFIG.outer_diameter_mm,
+          height_mm:         state.height_mm,
+          quantity:          state.quantity === 'pair' ? 2 : 1
+        };
+        cart_add(item);
+        show_snackbar('Added to cart');
+        var drawer = document.querySelector('cart-drawer');
+        if (drawer) drawer.open();
+      });
+    }
+  });
+
+  customElements.define('cart-drawer', class extends HTMLElement {
+    connectedCallback() {
+      this._render();
+      window.addEventListener('mitthen:cart-updated', function () {
+        this._render();
+      }.bind(this));
+    }
+
+    open() {
+      this.classList.add('is-open');
+      document.body.classList.add('cart-drawer-open');
+    }
+
+    close() {
+      this.classList.remove('is-open');
+      document.body.classList.remove('cart-drawer-open');
+    }
+
+    _render() {
+      var self = this;
+      var items = cart_load();
+
+      var items_html;
+      if (items.length === 0) {
+        items_html = '<p class="cart-empty">Your cart is empty.</p>';
+      } else {
+        items_html = '<ul class="cart-item-list">' +
+          items.map(function (item, index) {
+            var spec = item.inner_diameter_mm + '\u200amm ID \u00b7 ' +
+                       item.height_mm + '\u200amm tall \u00b7 qty\u00a0' + item.quantity;
+            return '<li class="cart-item" data-index="' + index + '">' +
+              '<div class="cart-item-spec">' + spec + '</div>' +
+              '<div class="cart-item-price" data-index="' + index + '">CHF \u2014</div>' +
+              '<button class="cart-item-remove" data-index="' + index + '" aria-label="Remove item">&times;</button>' +
+            '</li>';
+          }).join('') +
+        '</ul>';
+      }
+
+      var footer_html = items.length > 0
+        ? '<div class="cart-footer">' +
+            '<div class="cart-total" id="cart-total">Total: CHF \u2014</div>' +
+            '<button class="checkout-btn cart-checkout-btn" id="cart-checkout-btn">Checkout</button>' +
+            '<div class="checkout-error" id="cart-checkout-error"></div>' +
+          '</div>'
+        : '';
+
+      this.innerHTML =
+        '<div class="cart-backdrop"></div>' +
+        '<div class="cart-panel">' +
+          '<div class="cart-header">' +
+            '<span class="cart-title">Cart</span>' +
+            '<button class="cart-close" aria-label="Close cart">&times;</button>' +
+          '</div>' +
+          '<div class="cart-body">' + items_html + '</div>' +
+          footer_html +
+        '</div>';
+
+      // Wire close
+      this.querySelector('.cart-backdrop').addEventListener('click', function () { self.close(); });
+      this.querySelector('.cart-close').addEventListener('click', function () { self.close(); });
+
+      // Wire remove buttons
+      this.querySelectorAll('.cart-item-remove').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var idx = parseInt(btn.dataset.index, 10);
+          cart_remove(idx);
+        });
+      });
+
+      // Wire checkout
+      var checkout_btn = this.querySelector('#cart-checkout-btn');
+      if (checkout_btn) {
+        checkout_btn.addEventListener('click', async function () {
+          var error_el = self.querySelector('#cart-checkout-error');
+          checkout_btn.disabled = true;
+          checkout_btn.textContent = 'Processing...';
+          if (error_el) error_el.textContent = '';
+
+          var checkout_items = cart_load().map(function (i) {
+            return {
+              inner_diameter_mm: i.inner_diameter_mm,
+              outer_diameter_mm: i.outer_diameter_mm,
+              height_mm:         i.height_mm,
+              quantity:          i.quantity
+            };
+          });
+
+          try {
+            var response = await fetch(WORKER_URL + '/checkout', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ items: checkout_items })
+            });
+            var data = await response.json();
+            if (data.url) {
+              window.location.href = data.url;
+            } else {
+              throw new Error(data.error || 'Unexpected error');
+            }
+          } catch (err) {
+            if (error_el) error_el.textContent = 'Checkout failed \u2014 please try again.';
+            checkout_btn.disabled = false;
+            checkout_btn.textContent = 'Checkout';
+          }
+        });
+      }
+
+      // Fetch prices asynchronously
+      if (items.length > 0) {
+        self._fetch_prices(items);
+      }
+    }
+
+    async _fetch_prices(items) {
+      var self = this;
+      var total = 0;
+      var fetches = items.map(async function (item, index) {
+        var params = new URLSearchParams({
+          inner_diameter_mm: item.inner_diameter_mm,
+          outer_diameter_mm: item.outer_diameter_mm,
+          height_mm:         item.height_mm,
+          quantity:          item.quantity
+        });
+        try {
+          var response = await fetch(WORKER_URL + '/price?' + params);
+          var data = await response.json();
+          var price_el = self.querySelector('.cart-item-price[data-index="' + index + '"]');
+          if (price_el) price_el.textContent = 'CHF ' + data.total_price_chf.toFixed(2);
+          total += data.total_price_chf;
+        } catch (e) {
+          // leave as em dash
+        }
+      });
+      await Promise.all(fetches);
+      var total_el = self.querySelector('#cart-total');
+      if (total_el) total_el.textContent = 'Total: CHF ' + total.toFixed(2);
     }
   });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -365,6 +365,186 @@ a:hover {
   transform: translateX(-50%) translateY(0);
 }
 
+/* Cart icon in header */
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cart-icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text);
+  padding: 0.25rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.cart-icon-btn:hover { color: var(--accent); }
+
+.cart-icon-svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.cart-badge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  min-width: 1rem;
+  height: 1rem;
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+  line-height: 1;
+}
+
+/* Add to cart button */
+.add-to-cart-btn {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+  padding: 0.85rem 2rem;
+  background: var(--text);
+  color: var(--bg);
+  border: none;
+  border-radius: 4px;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.add-to-cart-btn:hover { opacity: 0.8; }
+
+/* Cart drawer */
+cart-drawer { display: contents; }
+
+.cart-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 200;
+}
+
+.cart-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(380px, 100vw);
+  background: var(--bg);
+  border-left: 1.5px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.25s ease;
+  z-index: 201;
+}
+
+cart-drawer.is-open .cart-backdrop { display: block; }
+cart-drawer.is-open .cart-panel { transform: translateX(0); }
+
+.cart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1.5px solid var(--border);
+}
+
+.cart-title {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.04em;
+}
+
+.cart-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--muted);
+  line-height: 1;
+  padding: 0.25rem;
+}
+
+.cart-close:hover { color: var(--text); }
+
+.cart-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem;
+}
+
+.cart-empty {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.cart-item-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cart-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.cart-item-spec { font-size: 0.875rem; }
+
+.cart-item-price {
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.cart-item-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  color: var(--muted);
+  line-height: 1;
+  padding: 0.1rem 0.25rem;
+}
+
+.cart-item-remove:hover { color: var(--accent); }
+
+.cart-footer {
+  padding: 1.25rem 1.5rem;
+  border-top: 1.5px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cart-total {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 1.4rem;
+  letter-spacing: 0.04em;
+}
+
+.cart-checkout-btn { max-width: none; }
+
 @media (max-width: 600px) {
   header { padding: 1rem 1.25rem; }
   main { padding: 2.5rem 1.25rem; }

--- a/barbell-collar-1inch-to-2inch-adapter.md
+++ b/barbell-collar-1inch-to-2inch-adapter.md
@@ -14,6 +14,6 @@ Adapt your 1-inch barbell / dumbbell / loading pin to fit 2-inch Olympic weight 
 <quantity-picker></quantity-picker>
 
 <price-display></price-display>
-<buy-button></buy-button>
+<add-to-cart-button></add-to-cart-button>
 
 <back-to-shop></back-to-shop>


### PR DESCRIPTION
Closes #9

Adds cart functionality across the site:
- Cart state persisted in `localStorage` (`mitthen_cart`); duplicate configs are merged by summing quantity
- `<add-to-cart-button>` custom element adds current picker state to cart and opens the drawer
- `<cart-drawer>` custom element: slide-in panel with all items, live prices (fetched from worker), per-item remove, running total, and Checkout button that sends all items to the worker
- Cart count badge in the header — updates on add/remove and syncs across tabs via the `storage` event
- `barbell-collar-1inch-to-2inch-adapter.md` now uses `<add-to-cart-button>` instead of `<buy-button>`

## Test plan

- [ ] Add to cart opens drawer and shows item with price
- [ ] Adding same config twice merges into one item with summed quantity
- [ ] Remove button removes item; cart empties correctly
- [ ] Cart persists after page refresh
- [ ] Header badge count is correct and updates live
- [ ] Checkout button sends all items to worker and redirects to Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)