### PR TITLE
feat: add manufacturing tolerance info to product page

### DIFF
--- a/barbell-collar-1inch-to-2inch-adapter.md
+++ b/barbell-collar-1inch-to-2inch-adapter.md
@@ -9,6 +9,8 @@ title: Barbell Collar 1 Inch to 2 Inch Adapter
 
 Adapt your 1-inch barbell / dumbbell / loading pin to fit 2-inch Olympic weight plates. Solid construction, secure fit — no wobble, no compromise.
 
+Manufacturing tolerance: ±0.3mm.
+
 <unit-toggle></unit-toggle>
 <inner-diameter-picker></inner-diameter-picker>
 <height-picker></height-picker>


### PR DESCRIPTION
## Summary
- Adds manufacturing tolerance (±0.3mm) to the product description on the barbell collar adapter page

Closes #20

## Test plan
- [ ] Verify the tolerance note appears below the product description
- [ ] Confirm page layout is not disrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)