### PR TITLE
fix: rename contact email from hello@ to contact@mitthen.com

### DIFF
--- a/order-confirmed.md
+++ b/order-confirmed.md
@@ -6,7 +6,7 @@ title: Thank You
 <div style="text-align: center; padding: 2rem 0;">
   <h1>Thank You!</h1>
   <p>Your order is confirmed. You'll receive a confirmation email shortly.</p>
-  <p>If you have any questions, reach out at <a href="mailto:contact@mitthen.com">hello@mitthen.com</a>.</p>
+  <p>If you have any questions, reach out at <a href="mailto:contact@mitthen.com">contact@mitthen.com</a>.</p>
   <br>
   <a href="{{ '/' | relative_url }}" class="back-link">← Back to shop</a>
 </div>


### PR DESCRIPTION
## Summary
- Updates the display text in the order confirmation page from `hello@mitthen.com` to `contact@mitthen.com`
- The `mailto:` href was already pointing to `contact@mitthen.com`

Closes #23

## Test plan
- [ ] Verify the order confirmation page shows `contact@mitthen.com` as both the link text and mailto target

🤖 Generated with [Claude Code](https://claude.com/claude-code)