### PR TITLE
feat: add preview URL check for Cloudflare Pages deployments

### DIFF
--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,0 +1,68 @@
+name: Preview URL
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: read
+    steps:
+      - name: Wait for Cloudflare Pages build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+          for i in $(seq 1 40); do
+            RESULT=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" \
+              --jq '.check_runs[] | select(.name == "Cloudflare Pages") | "\(.status) \(.conclusion)"')
+            STATUS=$(echo "$RESULT" | awk '{print $1}')
+            CONCLUSION=$(echo "$RESULT" | awk '{print $2}')
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "Cloudflare Pages build succeeded"
+                exit 0
+              else
+                echo "::error::Cloudflare Pages build failed ($CONCLUSION)"
+                exit 1
+              fi
+            fi
+            echo "Waiting for Cloudflare Pages... (attempt $i/40)"
+            sleep 15
+          done
+          echo "::error::Timed out waiting for Cloudflare Pages (10 minutes)"
+          exit 1
+
+      - name: Post preview URL
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          SLUG=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]')
+          URL="https://${SLUG}.mitthen.pages.dev"
+          SHA_SHORT=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          BODY="### Cloudflare Pages Preview
+
+          :link: ${URL}
+
+          Deployed from commit ${SHA_SHORT}."
+
+          # Remove leading whitespace from heredoc-style indentation
+          BODY=$(echo "$BODY" | sed 's/^          //')
+
+          # Update existing comment or create a new one
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | contains("Cloudflare Pages Preview"))] | .[0].id // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              --method PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --method POST -f body="$BODY"
+          fi


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers on PR open/sync
- Polls until the Cloudflare Pages check completes (up to 10 min)
- Posts the preview URL as a PR comment (updates existing comment on new pushes)
- Fails the check if the Cloudflare build fails or times out

Closes #28

## Test plan
- [ ] Open or push to a PR and verify the workflow runs
- [ ] Confirm a comment appears with the preview URL after Cloudflare builds
- [ ] Verify the comment updates (not duplicates) on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)