### PR TITLE
fix: clear cart on order-confirmed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,6 +41,18 @@
         badge.textContent = n;
         if (n > 0) { badge.removeAttribute('hidden'); } else { badge.setAttribute('hidden', ''); }
       }
+      // If the customer lands on the order-confirmed page, clear the cart.
+      // This prevents stale items/counts if they retry checkout.
+      var path = (window.location.pathname || '');
+      if (/\/order-confirmed(\/|$)/.test(path)) {
+        try {
+          localStorage.setItem(CART_KEY, JSON.stringify([]));
+        } catch (e) {
+          // ignore
+        }
+        window.dispatchEvent(new CustomEvent('mitthen:cart-updated'));
+      }
+
       update_badge();
       window.addEventListener('mitthen:cart-updated', update_badge);
       window.addEventListener('storage', function (e) { if (e.key === CART_KEY) update_badge(); });

--- a/assets/product.js
+++ b/assets/product.js
@@ -619,13 +619,6 @@
 
   // Wrap pickers in the variant-selector div once DOM is ready
   document.addEventListener('DOMContentLoaded', function () {
-    // Clear cart only after the customer lands on the confirmation page.
-    // This avoids emptying the cart if the payment link fails and the customer retries.
-    var path = (window.location.pathname || '');
-    if (/\/order-confirmed(\/|$)/.test(path)) {
-      cart_clear();
-    }
-
     var pickers = document.querySelectorAll('unit-toggle, inner-diameter-picker, outer-diameter-display, height-picker, quantity-picker');
     if (pickers.length === 0) return;
     var wrapper = document.createElement('div');


### PR DESCRIPTION
Fix cart clearing to occur when landing on /order-confirmed (not on checkout click), preventing stale counts if checkout retries.