### PR TITLE
fix: cart drawer available on all pages

### DIFF
--- a/_layouts/barbell-adapter.html
+++ b/_layouts/barbell-adapter.html
@@ -15,6 +15,3 @@ layout: default
 {{ content }}
 
 <div class="snackbar" id="snackbar"></div>
-<cart-drawer></cart-drawer>
-
-<script src="{{ '/assets/product.js' | relative_url }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,6 +62,19 @@
       });
     })();
   </script>
+  <div class="snackbar" id="snackbar"></div>
+  <div id="product-config" style="display:none"
+    data-us-diameter="{{ site.data.collar_config.standard_us_sleeve_diameter_mm }}"
+    data-eu-diameter="{{ site.data.collar_config.standard_eu_sleeve_diameter_mm }}"
+    data-outer-diameter="{{ site.data.collar_config.outer_diameter_mm }}"
+    data-height-min="{{ site.data.collar_config.height_min_mm }}"
+    data-height-max="{{ site.data.collar_config.height_max_mm }}"
+    data-height-default="{{ site.data.collar_config.default_height_mm }}"
+    data-worker-url="{{ site.worker_url }}"
+  ></div>
+  <cart-drawer></cart-drawer>
+  <script src="{{ '/assets/product.js' | relative_url }}"></script>
+
   <main>
     {{ content }}
   </main>


### PR DESCRIPTION
Move cart drawer into the default layout and ensure product.js + product-config are loaded so the cart icon can open the cart from any page.