### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Space+Grotesk:wght@300;400;500&display=swap" rel="stylesheet">
   <link rel="icon" href="{{ '/assets/logo.png' | relative_url }}" type="image/png">
   <link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-QWQ9Z1NK24"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-QWQ9Z1NK24');
+  </script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- Add Google Analytics (gtag.js) snippet with tracking ID `G-QWQ9Z1NK24` to the default layout `<head>`
- Loads on all pages since every page uses the default layout

## Test plan
- [ ] Verify the site builds and pages load without errors
- [ ] Check the Network tab for `gtag/js` requests firing on page load
- [ ] Confirm events appear in the Google Analytics real-time dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)