### PR TITLE
feat: add Google Analytics ecommerce events

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,6 +53,9 @@
       // This prevents stale items/counts if they retry checkout.
       var path = (window.location.pathname || '');
       if (/\/order-confirmed(\/|$)/.test(path)) {
+        if (typeof gtag === 'function') {
+          gtag('event', 'purchase', { event_category: 'ecommerce' });
+        }
         try {
           localStorage.setItem(CART_KEY, JSON.stringify([]));
         } catch (e) {

--- a/assets/product.js
+++ b/assets/product.js
@@ -340,6 +340,9 @@
         '<div class="checkout-error" id="checkout-error"></div>';
 
       this.querySelector('#checkout-btn').addEventListener('click', async function () {
+        if (typeof gtag === 'function') {
+          gtag('event', 'begin_checkout', { event_category: 'ecommerce' });
+        }
         var btn = this.querySelector('#checkout-btn');
         var error_element = this.querySelector('#checkout-error');
         btn.disabled = true;
@@ -457,6 +460,13 @@
           height_display:         state.height_display
         };
         cart_add(item);
+        if (typeof gtag === 'function') {
+          gtag('event', 'add_to_cart', {
+            event_category: 'ecommerce',
+            event_label: item.inner_diameter_mm + 'x' + item.outer_diameter_mm + 'x' + item.height_mm,
+            value: item.quantity
+          });
+        }
         show_snackbar('Added to cart');
         var drawer = document.querySelector('cart-drawer');
         if (drawer) drawer.open();
@@ -540,6 +550,9 @@
       var checkout_btn = this.querySelector('#cart-checkout-btn');
       if (checkout_btn) {
         checkout_btn.addEventListener('click', async function () {
+          if (typeof gtag === 'function') {
+            gtag('event', 'begin_checkout', { event_category: 'ecommerce' });
+          }
           var error_el = self.querySelector('#cart-checkout-error');
           checkout_btn.disabled = true;
           checkout_btn.textContent = 'Processing...';


### PR DESCRIPTION
## Summary
- Track `add_to_cart` event when users click "Add to Cart" (includes product dimensions and quantity)
- Track `begin_checkout` event when users click "Checkout" in the cart drawer or "Buy Now" on the product page
- Track `purchase` event when users land on the order-confirmed page

These three events form a conversion funnel in GA: add to cart -> begin checkout -> purchase.

## Test plan
- [ ] Add an item to cart, verify `add_to_cart` event fires in GA real-time events
- [ ] Click checkout, verify `begin_checkout` event fires
- [ ] Visit `/order-confirmed`, verify `purchase` event fires
- [ ] Confirm no JS errors in console on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)