### PR TITLE
feat: add view_item GA event on product pages

### DIFF
--- a/_layouts/barbell-adapter.html
+++ b/_layouts/barbell-adapter.html
@@ -14,4 +14,13 @@ layout: default
 
 {{ content }}
 
+<script>
+  if (typeof gtag === 'function') {
+    gtag('event', 'view_item', {
+      event_category: 'ecommerce',
+      event_label: document.title
+    });
+  }
+</script>
+
 <div class="snackbar" id="snackbar"></div>


### PR DESCRIPTION
## Summary
- Fire `view_item` event when a product page (barbell-adapter layout) loads
- Completes the ecommerce funnel: view_item -> add_to_cart -> begin_checkout -> purchase

## Test plan
- [ ] Visit a product page, verify `view_item` event fires in GA real-time events
- [ ] Confirm non-product pages (homepage, order-confirmed) do not fire the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)