### PR TITLE
fix: use GA4 ecommerce items format for all events

### DIFF
--- a/_layouts/barbell-adapter.html
+++ b/_layouts/barbell-adapter.html
@@ -17,8 +17,10 @@ layout: default
 <script>
   if (typeof gtag === 'function') {
     gtag('event', 'view_item', {
-      event_category: 'ecommerce',
-      event_label: document.title
+      currency: 'CHF',
+      items: [{
+        item_name: document.title
+      }]
     });
   }
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,7 +54,17 @@
       var path = (window.location.pathname || '');
       if (/\/order-confirmed(\/|$)/.test(path)) {
         if (typeof gtag === 'function') {
-          gtag('event', 'purchase', { event_category: 'ecommerce' });
+          var ga_items = [];
+          try {
+            ga_items = JSON.parse(localStorage.getItem(CART_KEY) || '[]').map(function (i) {
+              return {
+                item_name: 'Barbell Collar Adapter',
+                item_variant: i.inner_diameter_mm + 'x' + i.outer_diameter_mm + 'x' + i.height_mm,
+                quantity: i.quantity
+              };
+            });
+          } catch (e) {}
+          gtag('event', 'purchase', { currency: 'CHF', items: ga_items });
         }
         try {
           localStorage.setItem(CART_KEY, JSON.stringify([]));

--- a/assets/product.js
+++ b/assets/product.js
@@ -341,7 +341,14 @@
 
       this.querySelector('#checkout-btn').addEventListener('click', async function () {
         if (typeof gtag === 'function') {
-          gtag('event', 'begin_checkout', { event_category: 'ecommerce' });
+          gtag('event', 'begin_checkout', {
+            currency: 'CHF',
+            items: [{
+              item_name: 'Barbell Collar Adapter',
+              item_variant: state.inner_diameter_mm + 'x' + CONFIG.outer_diameter_mm + 'x' + state.height_mm,
+              quantity: state.quantity === 'pair' ? 2 : 1
+            }]
+          });
         }
         var btn = this.querySelector('#checkout-btn');
         var error_element = this.querySelector('#checkout-error');
@@ -462,9 +469,12 @@
         cart_add(item);
         if (typeof gtag === 'function') {
           gtag('event', 'add_to_cart', {
-            event_category: 'ecommerce',
-            event_label: item.inner_diameter_mm + 'x' + item.outer_diameter_mm + 'x' + item.height_mm,
-            value: item.quantity
+            currency: 'CHF',
+            items: [{
+              item_name: 'Barbell Collar Adapter',
+              item_variant: item.inner_diameter_mm + 'x' + item.outer_diameter_mm + 'x' + item.height_mm,
+              quantity: item.quantity
+            }]
           });
         }
         show_snackbar('Added to cart');
@@ -551,7 +561,14 @@
       if (checkout_btn) {
         checkout_btn.addEventListener('click', async function () {
           if (typeof gtag === 'function') {
-            gtag('event', 'begin_checkout', { event_category: 'ecommerce' });
+            var ga_items = cart_load().map(function (i) {
+              return {
+                item_name: 'Barbell Collar Adapter',
+                item_variant: i.inner_diameter_mm + 'x' + i.outer_diameter_mm + 'x' + i.height_mm,
+                quantity: i.quantity
+              };
+            });
+            gtag('event', 'begin_checkout', { currency: 'CHF', items: ga_items });
           }
           var error_el = self.querySelector('#cart-checkout-error');
           checkout_btn.disabled = true;


### PR DESCRIPTION
## Summary
- Switch all GA events (`view_item`, `add_to_cart`, `begin_checkout`, `purchase`) from old Universal Analytics `event_category`/`event_label` params to GA4's required `currency` + `items` array format
- Without this format, GA4 doesn't recognize the events as ecommerce events, so they don't appear in the funnel or sync to Google Ads

## Test plan
- [ ] Add item to cart — check GA4 real-time shows `add_to_cart` with item details
- [ ] Click checkout — check `begin_checkout` appears with items
- [ ] Visit `/order-confirmed` — check `purchase` appears
- [ ] Visit product page — check `view_item` appears
- [ ] Verify events show up in **Admin > Events** as ecommerce events

🤖 Generated with [Claude Code](https://claude.com/claude-code)