### PR TITLE
feat: enable GA4 debug_mode on non-production domains

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-QWQ9Z1NK24');
+    var ga_config = {};
+    if (window.location.hostname !== 'mitthen.com') {
+      ga_config.debug_mode = true;
+    }
+    gtag('config', 'G-QWQ9Z1NK24', ga_config);
   </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- On `mitthen.com`: GA works normally, events go to production reports
- On any other hostname (Cloudflare Pages previews, localhost): GA runs in `debug_mode`, events appear only in **Admin > DebugView** without polluting production data

## Test plan
- [ ] Deploy to a Cloudflare Pages preview, open GA4 **Admin > DebugView**, verify events show up there
- [ ] Verify events do NOT appear in regular GA4 reports from preview domains
- [ ] Visit production site, confirm events still appear in regular reports as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)