### PR TITLE
feat: add sitemap.xml and robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,9 @@
+---
+layout: null
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+Disallow: /order-confirmed
+
+Sitemap: {{ site.url }}/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,20 @@
+---
+layout: null
+permalink: /sitemap.xml
+sitemap:
+  exclude: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% assign pages = site.pages | where_exp: "p", "p.sitemap.exclude != true" %}
+{% for page in pages %}
+{% assign ext = page.path | split: "." | last %}
+{% if ext == "md" or ext == "html" %}
+{% if page.name == "order-confirmed.md" %}{% continue %}{% endif %}
+  <url>
+    <loc>{{ page.url | replace: "/index.html", "/" | absolute_url }}</loc>
+    {% if page.last_modified_at %}<lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>{% endif %}
+  </url>
+{% endif %}
+{% endfor %}
+</urlset>


### PR DESCRIPTION
## Summary
- Adds Jekyll-templated `sitemap.xml` listing real pages (home + product), excluding the post-checkout `order-confirmed` page.
- Adds `robots.txt` pointing crawlers at the sitemap and disallowing `/order-confirmed`.

## Test plan
- [ ] Build with Jekyll and verify `/sitemap.xml` lists `/` and `/barbell-collar-1inch-to-2inch-adapter` only.
- [ ] Verify `/robots.txt` resolves and references the absolute sitemap URL.
- [ ] (Post-deploy) Submit sitemap in Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)