### PR TITLE
feat: SEO meta, structured data, and keyword-rich copy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 title: Mitthen
+description: "Mitthen makes barbell adapters and lifting gear. Universal weight plate adapters that fit 2 inch Olympic plates onto 1 inch sleeves on dumbbells, barbells, and loading pins."
 url: "https://mitthen.com"
 worker_url: "https://mitthen-checkout.mitthen-com.workers.dev"

--- a/_layouts/barbell-adapter.html
+++ b/_layouts/barbell-adapter.html
@@ -14,6 +14,30 @@ layout: default
 
 {{ content }}
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "{{ page.product.name }}",
+  "description": "{{ page.description }}",
+  "image": [
+    "{{ '/assets/img/adapter-1040.jpg' | absolute_url }}",
+    "{{ '/assets/img/img-6587-1040.jpg' | absolute_url }}",
+    "{{ '/assets/img/img-detail-1040.jpg' | absolute_url }}"
+  ],
+  "sku": "{{ page.product.sku }}",
+  "brand": { "@type": "Brand", "name": "{{ site.title }}" }{% if page.product.low_price %},
+  "offers": {
+    "@type": "AggregateOffer",
+    "priceCurrency": "{{ page.product.currency | default: 'CHF' }}",
+    "lowPrice": "{{ page.product.low_price }}",
+    "highPrice": "{{ page.product.high_price }}",
+    "availability": "https://schema.org/InStock",
+    "url": "{{ page.url | absolute_url }}"
+  }{% endif %}
+}
+</script>
+
 <script>
   if (typeof gtag === 'function') {
     gtag('event', 'view_item', {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if page.title %}{{ page.title }} — {% endif %}{{ site.title }}</title>
+  {% assign page_title = page.seo_title | default: page.title %}
+  {% if page_title %}
+  <title>{{ page_title }} | {{ site.title }}</title>
+  {% else %}
+  <title>{{ site.title }}</title>
+  {% endif %}
+  {% assign page_description = page.description | default: site.description %}
+  <meta name="description" content="{{ page_description }}">
+  <link rel="canonical" href="{{ page.url | replace: '/index.html', '/' | absolute_url }}">
+
+  <meta property="og:site_name" content="{{ site.title }}">
+  <meta property="og:type" content="{% if page.product %}product{% else %}website{% endif %}">
+  <meta property="og:title" content="{{ page_title | default: site.title }}">
+  <meta property="og:description" content="{{ page_description }}">
+  <meta property="og:url" content="{{ page.url | replace: '/index.html', '/' | absolute_url }}">
+  {% assign og_image = page.preload_image | default: 'adapter' %}
+  <meta property="og:image" content="{{ og_image | append: '-1040.jpg' | prepend: '/assets/img/' | absolute_url }}">
+  <meta property="og:image:width" content="1040">
+  <meta property="og:image:height" content="1040">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ page_title | default: site.title }}">
+  <meta name="twitter:description" content="{{ page_description }}">
+  <meta name="twitter:image" content="{{ og_image | append: '-1040.jpg' | prepend: '/assets/img/' | absolute_url }}">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Space+Grotesk:wght@300;400;500&display=swap">
@@ -14,6 +37,15 @@
   {% if page.preload_image %}
   <link rel="preload" as="image" type="image/webp" imagesrcset="{{ page.preload_image | append: '-520.webp' | prepend: '/assets/img/' | relative_url }} 1x, {{ page.preload_image | append: '-1040.webp' | prepend: '/assets/img/' | relative_url }} 2x">
   {% endif %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "{{ site.title }}",
+    "url": "{{ site.url }}",
+    "logo": "{{ '/assets/img/logo-160.png' | absolute_url }}"
+  }
+  </script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-QWQ9Z1NK24"></script>
   <script>

--- a/assets/product.js
+++ b/assets/product.js
@@ -390,6 +390,7 @@
       var src_list = (this.getAttribute('images') || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean);
       if (src_list.length === 0) return;
 
+      var alt_text = (this.getAttribute('alt') || '').replace(/"/g, '&quot;');
       var index = 0;
       var self = this;
 
@@ -403,7 +404,7 @@
         var priority_attr = is_active ? ' fetchpriority="high"' : '';
         return '<picture>' +
             '<source type="image/webp" srcset="/assets/img/' + src + '-520.webp 1x, /assets/img/' + src + '-1040.webp 2x">' +
-            '<img class="gallery-media" src="/assets/img/' + src + '-520.jpg" srcset="/assets/img/' + src + '-520.jpg 1x, /assets/img/' + src + '-1040.jpg 2x" alt="" width="520" height="520" decoding="async" loading="' + loading_attr + '"' + priority_attr + '>' +
+            '<img class="gallery-media" src="/assets/img/' + src + '-520.jpg" srcset="/assets/img/' + src + '-520.jpg 1x, /assets/img/' + src + '-1040.jpg 2x" alt="' + alt_text + '" width="520" height="520" decoding="async" loading="' + loading_attr + '"' + priority_attr + '>' +
           '</picture>';
       }
 

--- a/barbell-collar-1inch-to-2inch-adapter.md
+++ b/barbell-collar-1inch-to-2inch-adapter.md
@@ -1,16 +1,21 @@
 ---
 layout: barbell-adapter
-title: Barbell Collar 1 Inch to 2 Inch Adapter
+title: 1″ to 2″ Barbell Adapter
+seo_title: "1\" to 2\" Barbell Adapter for Olympic Weight Plates"
+description: "Universal barbell adapter that fits 2 inch Olympic weight plates onto 1 inch sleeves. Works on dumbbells, barbells, and loading pins. Adjustable height, ±0.3mm tolerance."
 preload_image: adapter
+product:
+  name: "1 inch to 2 inch Barbell Adapter"
+  sku: "MTN-ADP-1TO2"
 ---
 
-<product-gallery images="adapter, img-6587, img-detail"></product-gallery>
+<product-gallery images="adapter, img-6587, img-detail" alt="1 inch to 2 inch barbell adapter for Olympic weight plates"></product-gallery>
 
-# Barbell Collar 1″ to 2″ Adapter
+# 1″ to 2″ Barbell Adapter
 
-This adapter lets you use 2-inch (50mm) Olympic weight plates on equipment with 1-inch (25mm) sleeves, like adjustable dumbbells, standard barbells, and loading pins. It fits snug and keeps the plates centered.
+This barbell sleeve insert lets you use 2-inch (50mm) Olympic weight plates on equipment with 1-inch (25mm) sleeves, like adjustable dumbbells, standard barbells, and loading pins. It fits snug and keeps the plates centered.
 
-You need one per sleeve, so a pair works for dumbbells and barbells. Manufacturing tolerance: ±0.3mm.
+You need one weight plate adapter per sleeve, so a pair works for dumbbells and barbells. Pick the inner diameter to match your bar (US 1″ or EU 30mm), set the height for your plates, and you're done. Manufacturing tolerance: ±0.3mm.
 
 <div class="variant-selector">
   <unit-toggle></unit-toggle>

--- a/index.md
+++ b/index.md
@@ -1,10 +1,12 @@
 ---
 layout: default
+seo_title: "Barbell Adapters and Lifting Gear"
+description: "Mitthen makes universal barbell adapters that fit 2 inch Olympic weight plates onto 1 inch sleeves on dumbbells, barbells, and loading pins."
 ---
 
 <div class="intro">
   <h1>Mitthen</h1>
-  <p>Gear for people who lift.</p>
+  <p>Barbell adapters and gear for people who lift.</p>
 </div>
 
 <div class="products">
@@ -13,12 +15,12 @@ layout: default
     <div class="product-card-thumb">
       <picture>
         <source type="image/webp" srcset="{{ '/assets/img/adapter-144.webp' | relative_url }}">
-        <img src="{{ '/assets/img/adapter-144.jpg' | relative_url }}" alt="Barbell Collar Adapter" width="72" height="72" decoding="async">
+        <img src="{{ '/assets/img/adapter-144.jpg' | relative_url }}" alt="1 inch to 2 inch barbell adapter for Olympic weight plates" width="72" height="72" decoding="async">
       </picture>
     </div>
     <div class="product-card-info">
-      <div class="product-card-title">Barbell Collar 1&Prime; to 2&Prime; Adapter</div>
-      <div class="product-card-sub">Fit Olympic plates on a 1 inch barbell / dumbbell / loading pin</div>
+      <div class="product-card-title">1&Prime; to 2&Prime; Barbell Adapter</div>
+      <div class="product-card-sub">Universal weight plate adapter for dumbbells, barbells, and loading pins. Fits Olympic plates on 1 inch sleeves.</div>
     </div>
   </a>
 </div>


### PR DESCRIPTION
## Summary
Targets the trending keywords (barbell adapter, weight plate adapter, plate hold adapter) plus supporting variants (barbell sleeve insert, universal weight plate adapter, Olympic weight plates, dumbbell / barbell / loading pin sleeves) without keyword-stuffing.

### Head meta
- Title pattern: \`{seo_title or title} | Mitthen\` driven by front matter.
- \`<meta name="description">\`, canonical URL.
- Open Graph (\`og:type=product\` on the product page, \`website\` elsewhere) and Twitter \`summary_large_image\` cards. \`og:image\` defaults to the optimized 1040 jpg.

### Structured data
- **Organization** JSON-LD sitewide.
- **Product** JSON-LD on the product page (name, description, image, brand, sku). \`offers\` is left conditional on \`page.product.low_price\` because the pricing formula lives in the Cloudflare worker; you can fill it in later for richer SERP results.

### Copy changes
- **Home H1**: \`Mitthen\` (kept). Subtitle now \`Barbell adapters and gear for people who lift.\`
- **Product card**: title \`1″ to 2″ Barbell Adapter\`; sub \`Universal weight plate adapter for dumbbells, barbells, and loading pins. Fits Olympic plates on 1 inch sleeves.\`
- **Product H1**: \`1″ to 2″ Barbell Adapter\` (was \`Barbell Collar 1″ to 2″ Adapter\`).
- **Product body**: works in \`barbell sleeve insert\` and \`weight plate adapter\` once each, plus a sentence on picking inner diameter / height.
- **Alt text**: gallery and home card images now carry \`1 inch to 2 inch barbell adapter for Olympic weight plates\`.

### Optional follow-ups (not in this PR)
- Fill in \`product.low_price\` / \`high_price\` / \`currency\` front matter on the product page once you decide on a public price range — that unlocks AggregateOffer rich results in Google.
- Submit the new \`sitemap.xml\` in Google Search Console.

## Test plan
- [ ] Inspect rendered HTML on \`/\` and \`/barbell-collar-1inch-to-2inch-adapter\`: title, description, canonical, og:*, twitter:* tags all populated correctly.
- [ ] Paste the product URL into the [Rich Results Test](https://search.google.com/test/rich-results) and confirm Product schema is valid.
- [ ] Paste the same URL into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) and confirm preview card image and copy.
- [ ] Verify gallery image alt text is set in DevTools.
- [ ] Skim the new copy: does it sound like Mitthen, not like an SEO blog post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)