### PR TITLE
feat: add Cloudflare Pages PR preview deployment workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,33 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Jekyll site
+        uses: docker://jekyll/builder:latest
+        env:
+          JEKYLL_ENV: production
+        with:
+          args: jekyll build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: mitthen-preview
+          directory: _site
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Resurrects the workflow from the orphan \`feat/pr-preview-deploys\` branch on a fresh base. Builds Jekyll on every PR and deploys the result to a Cloudflare Pages project (\`mitthen-preview\`) so each PR gets its own preview URL commented on the PR.

I did **not** carry over the rest of that old branch — it was based on a pre-perf, pre-SEO main and would have reverted optimized images, the inlined cart drawer, and the schema/meta work. Just the workflow file.

## What you need to do before this is useful
1. **Create the Pages project** in the Cloudflare dashboard: Pages → Create → Direct Upload, name it \`mitthen-preview\`. Skip git integration.
2. **Generate an API token** at My Profile → API Tokens with the *Cloudflare Pages: Edit* permission scoped to your account.
3. **Add two repo secrets** in GitHub Settings → Secrets and variables → Actions:
   - \`CLOUDFLARE_API_TOKEN\`
   - \`CLOUDFLARE_ACCOUNT_ID\` (Account Home → right sidebar)

## Caveats worth knowing before merge
- **\`cloudflare/pages-action@v1\` is deprecated.** It still works, but Cloudflare recommends \`cloudflare/wrangler-action@v3\` going forward. Want me to modernize it in this PR or leave that as a follow-up?
- **This is preview only, not a full migration.** If you decide to move production off GitHub Pages, you'll also need a workflow (or Cloudflare's git integration) for production deploys, plus a DNS cutover for \`mitthen.com\`. Happy to draft that as a separate PR once you decide.

## Test plan
- [ ] After secrets and the Pages project are set up, push a dummy commit to a feature branch and confirm the workflow runs and posts a preview URL on the PR.
- [ ] Open the preview URL and verify the site renders identically to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)