### PR TITLE
feat: add offerCount to AggregateOffer schema

### DIFF
--- a/_layouts/barbell-adapter.html
+++ b/_layouts/barbell-adapter.html
@@ -31,7 +31,8 @@ layout: default
     "@type": "AggregateOffer",
     "priceCurrency": "{{ page.product.currency | default: 'CHF' }}",
     "lowPrice": "{{ page.product.low_price }}",
-    "highPrice": "{{ page.product.high_price }}",
+    "highPrice": "{{ page.product.high_price }}",{% if page.product.offer_count %}
+    "offerCount": "{{ page.product.offer_count }}",{% endif %}
     "availability": "https://schema.org/InStock",
     "url": "{{ page.url | absolute_url }}"
   }{% endif %}

--- a/barbell-collar-1inch-to-2inch-adapter.md
+++ b/barbell-collar-1inch-to-2inch-adapter.md
@@ -10,6 +10,7 @@ product:
   currency: CHF
   low_price: "12.25"
   high_price: "21.22"
+  offer_count: "3360"
 ---
 
 <product-gallery images="adapter, img-6587, img-detail" alt="1 inch to 2 inch barbell adapter for Olympic weight plates"></product-gallery>


### PR DESCRIPTION
## Summary
Google's Rich Results Test flagged \`offerCount\` as a missing optional field on the \`AggregateOffer\`. Adding it.

\`\`\`
5 colors × 3 materials × 2 inner diameters × 56 heights × 2 (single/pair) = 3360
\`\`\`

The other two warnings (\`review\`, \`aggregateRating\`) need real customer reviews and are not in this PR — synthesizing them violates Google's review snippet guidelines.

## Test plan
- [ ] After merge + deploy, re-run [Rich Results Test](https://search.google.com/test/rich-results?url=https%3A%2F%2Fmitthen.com%2Fbarbell-collar-1inch-to-2inch-adapter) and confirm the \`offerCount\` warning is gone.
- [ ] If you ever change variant axes (more colors, height step), bump \`offer_count\` in the product front matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)