### PR TITLE
feat: add scroll easter egg after 10 consecutive scroll bursts

### DIFF
--- a/_includes/style.css
+++ b/_includes/style.css
@@ -736,3 +736,69 @@ cart-drawer.is-open .cart-panel { transform: translateX(0); }
   main { padding: 2.5rem 1.25rem; }
   .snackbar { white-space: normal; text-align: center; width: calc(100% - 3rem); }
 }
+
+.scroll-egg {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.scroll-egg.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.scroll-egg-card {
+  background: var(--bg);
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  padding: 2rem 1.75rem;
+  max-width: min(420px, calc(100% - 2rem));
+  text-align: center;
+  transform: translateY(8px) scale(0.98);
+  transition: transform 0.25s ease;
+}
+
+.scroll-egg.is-open .scroll-egg-card {
+  transform: translateY(0) scale(1);
+}
+
+.scroll-egg-title {
+  font-family: 'Bebas Neue', sans-serif;
+  font-size: 2rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.5rem;
+  color: var(--accent);
+}
+
+.scroll-egg-body {
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+  color: var(--text);
+}
+
+.scroll-egg-close {
+  padding: 0.65rem 1.5rem;
+  background: var(--text);
+  color: var(--bg);
+  border: none;
+  border-radius: 4px;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.scroll-egg-close:hover { opacity: 0.8; }
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-egg, .scroll-egg-card { transition: none; }
+}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -144,6 +144,77 @@
     data-worker-url="{{ site.worker_url }}"
   ></div>
   <cart-drawer></cart-drawer>
+  <div class="scroll-egg" id="scroll-egg" role="dialog" aria-modal="true" aria-labelledby="scroll-egg-title" aria-hidden="true">
+    <div class="scroll-egg-card">
+      <div class="scroll-egg-title" id="scroll-egg-title">You found it</div>
+      <p class="scroll-egg-body">Ha, this is so funny, you scroll 10 times.</p>
+      <button type="button" class="scroll-egg-close" id="scroll-egg-close">Back to scrolling</button>
+    </div>
+  </div>
+  <script>
+    (function () {
+      var BURST_GAP_MS = 250;
+      var RESET_AFTER_MS = 5000;
+      var TARGET = 10;
+
+      var overlay = document.getElementById('scroll-egg');
+      var close_btn = document.getElementById('scroll-egg-close');
+      if (!overlay || !close_btn) return;
+
+      var bursts = 0;
+      var last_scroll = 0;
+      var reset_timer = 0;
+      var is_open = false;
+
+      function reset() {
+        bursts = 0;
+        last_scroll = 0;
+        if (reset_timer) { clearTimeout(reset_timer); reset_timer = 0; }
+      }
+
+      function open_egg() {
+        if (is_open) return;
+        is_open = true;
+        overlay.classList.add('is-open');
+        overlay.setAttribute('aria-hidden', 'false');
+        close_btn.focus();
+        reset();
+      }
+
+      function close_egg() {
+        if (!is_open) return;
+        is_open = false;
+        overlay.classList.remove('is-open');
+        overlay.setAttribute('aria-hidden', 'true');
+      }
+
+      function on_scroll() {
+        if (is_open) return;
+        var now = Date.now();
+        if (now - last_scroll >= BURST_GAP_MS) {
+          bursts += 1;
+          last_scroll = now;
+          if (bursts >= TARGET) {
+            open_egg();
+            return;
+          }
+        } else {
+          last_scroll = now;
+        }
+        if (reset_timer) clearTimeout(reset_timer);
+        reset_timer = setTimeout(reset, RESET_AFTER_MS);
+      }
+
+      window.addEventListener('scroll', on_scroll, { passive: true });
+      close_btn.addEventListener('click', close_egg);
+      overlay.addEventListener('click', function (e) {
+        if (e.target === overlay) close_egg();
+      });
+      document.addEventListener('keydown', function (e) {
+        if (is_open && e.key === 'Escape') close_egg();
+      });
+    })();
+  </script>
   <script src="{{ '/assets/product.js' | relative_url }}" defer></script>
 
   <main>


### PR DESCRIPTION
## Summary
- Adds a site-wide easter egg: after 10 distinct scroll bursts in a row, an overlay pops up with a cheeky message
- "Burst" = scroll activity separated by at least 250ms (so a single trackpad flick counts once, not 30 times)
- Counter resets after 5s of no scrolling, so it really has to be "in a row"
- Overlay is dismissable via button, backdrop click, or Esc; counter resets after dismissal so it can fire again
- Respects `prefers-reduced-motion`

## Test plan
- [ ] Open any page (home, product page, order-confirmed) and scroll 10 times in a row — overlay appears with the message
- [ ] Click "Back to scrolling", click backdrop, and press Esc — each closes the overlay
- [ ] Scroll once, wait 6s, scroll again — counter resets (overlay does not appear after only ~10 total scrolls spread over time)
- [ ] Spam scroll wheel quickly — bursts gate at 250ms so it still requires ~10 distinct gestures
- [ ] Verify nothing visually regresses on mobile / narrow viewports